### PR TITLE
feat: rate limit rendering

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/josephburgess/gust/internal/models"
 )
@@ -15,19 +17,63 @@ type WeatherResponse struct {
 	Weather *models.OneCallResponse `json:"weather"`
 }
 
+type RateLimitInfo struct {
+	Limit     int
+	Remaining int
+	ResetTime time.Time
+}
+
 type Client struct {
-	baseURL string
-	apiKey  string
-	units   string
-	client  *http.Client
+	baseURL       string
+	apiKey        string
+	units         string
+	client        *http.Client
+	RateLimitInfo *RateLimitInfo
 }
 
 func NewClient(baseURL, apiKey string, units string) *Client {
 	return &Client{
-		baseURL: baseURL,
-		apiKey:  apiKey,
-		units:   units,
-		client:  &http.Client{},
+		baseURL:       baseURL,
+		apiKey:        apiKey,
+		units:         units,
+		client:        &http.Client{},
+		RateLimitInfo: &RateLimitInfo{},
+	}
+}
+
+func (c *Client) extractRateLimitInfo(resp *http.Response) {
+	if c.RateLimitInfo == nil {
+		c.RateLimitInfo = &RateLimitInfo{}
+	}
+
+	if limit := resp.Header.Get("X-RateLimit-Limit"); limit != "" {
+		if val, err := strconv.Atoi(limit); err == nil {
+			c.RateLimitInfo.Limit = val
+		}
+	}
+
+	if remaining := resp.Header.Get("X-RateLimit-Remaining"); remaining != "" {
+		if val, err := strconv.Atoi(remaining); err == nil {
+			c.RateLimitInfo.Remaining = val
+		} else {
+			c.RateLimitInfo.Remaining = 0
+		}
+	}
+
+	if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
+		resetTime, err := time.Parse(time.RFC3339, reset)
+		if err == nil {
+			c.RateLimitInfo.ResetTime = resetTime
+		} else {
+			c.RateLimitInfo.ResetTime = time.Now().Add(time.Hour)
+		}
+	}
+
+	if c.RateLimitInfo.Limit > 0 {
+		fmt.Printf("DEBUG: Rate limit: %d/%d, Reset: %s\n",
+			c.RateLimitInfo.Remaining,
+			c.RateLimitInfo.Limit,
+			c.RateLimitInfo.ResetTime.Format(time.RFC3339))
 	}
 }
 
@@ -48,6 +94,13 @@ func (c *Client) GetWeather(cityName string) (*WeatherResponse, error) {
 		return nil, fmt.Errorf("failed to connect to API: %w", err)
 	}
 	defer resp.Body.Close()
+
+	c.extractRateLimitInfo(resp)
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("rate limit exceeded: %s", string(body))
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -75,6 +128,13 @@ func (c *Client) SearchCities(query string) ([]models.City, error) {
 		return nil, fmt.Errorf("failed to connect to API: %w", err)
 	}
 	defer resp.Body.Close()
+
+	c.extractRateLimitInfo(resp)
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("rate limit exceeded: %s", string(body))
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -68,13 +68,6 @@ func (c *Client) extractRateLimitInfo(resp *http.Response) {
 			c.RateLimitInfo.ResetTime = time.Now().Add(time.Hour)
 		}
 	}
-
-	if c.RateLimitInfo.Limit > 0 {
-		fmt.Printf("DEBUG: Rate limit: %d/%d, Reset: %s\n",
-			c.RateLimitInfo.Remaining,
-			c.RateLimitInfo.Limit,
-			c.RateLimitInfo.ResetTime.Format(time.RFC3339))
-	}
 }
 
 func (c *Client) GetWeather(cityName string) (*WeatherResponse, error) {
@@ -124,17 +117,9 @@ func (c *Client) SearchCities(query string) ([]models.City, error) {
 
 	resp, err := c.client.Get(endpoint)
 	if err != nil {
-		fmt.Println("API request failed:", err)
 		return nil, fmt.Errorf("failed to connect to API: %w", err)
 	}
 	defer resp.Body.Close()
-
-	c.extractRateLimitInfo(resp)
-
-	if resp.StatusCode == http.StatusTooManyRequests {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("rate limit exceeded: %s", string(body))
-	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/internal/cli/weather_handler.go
+++ b/internal/cli/weather_handler.go
@@ -1,3 +1,5 @@
+// Update the internal/cli/weather_handler.go file
+
 package cli
 
 import (
@@ -9,6 +11,7 @@ import (
 	"github.com/josephburgess/gust/internal/config"
 	"github.com/josephburgess/gust/internal/models"
 	"github.com/josephburgess/gust/internal/ui/components"
+	"github.com/josephburgess/gust/internal/ui/output"
 	"github.com/josephburgess/gust/internal/ui/renderer"
 	"github.com/josephburgess/gust/internal/ui/styles"
 )
@@ -32,7 +35,7 @@ func fetchAndRenderWeather(city string, cfg *config.Config, authConfig *config.A
 
 	if client.RateLimitInfo != nil && client.RateLimitInfo.Limit > 0 {
 		if err != nil && strings.Contains(strings.ToLower(err.Error()), "rate limit") {
-			displayRateLimitError(0, client.RateLimitInfo.Limit, client.RateLimitInfo.ResetTime)
+			output.PrintRateLimitError(client.RateLimitInfo.Limit, client.RateLimitInfo.ResetTime)
 
 			timeUntilReset := time.Until(client.RateLimitInfo.ResetTime)
 			if timeUntilReset > 0 {
@@ -51,22 +54,13 @@ func fetchAndRenderWeather(city string, cfg *config.Config, authConfig *config.A
 			return fmt.Errorf("rate limit reached, please try again later")
 		}
 
-		if client.RateLimitInfo.Remaining <= 0 {
-			displayRateLimitError(0, client.RateLimitInfo.Limit, client.RateLimitInfo.ResetTime)
-		} else if client.RateLimitInfo.Remaining <= 5 {
-			displayRateLimitWarning(
+		if client.RateLimitInfo.Remaining <= 5 && client.RateLimitInfo.Remaining > 0 {
+			output.PrintRateLimitWarning(
 				client.RateLimitInfo.Remaining,
 				client.RateLimitInfo.Limit,
 				client.RateLimitInfo.ResetTime,
 			)
 		}
-
-		defer func() {
-			if client.RateLimitInfo.Remaining > 5 {
-				fmt.Println()
-				displayRateLimitStatus(client.RateLimitInfo.Remaining, client.RateLimitInfo.Limit)
-			}
-		}()
 	}
 
 	if err != nil {
@@ -77,74 +71,6 @@ func fetchAndRenderWeather(city string, cfg *config.Config, authConfig *config.A
 	renderWeatherView(cli, weatherRenderer, weather.City, weather.Weather, cfg)
 
 	return nil
-}
-
-func displayRateLimitWarning(remaining, limit int, resetTime time.Time) {
-	timeUntilReset := time.Until(resetTime)
-	minutesUntilReset := int(timeUntilReset.Minutes())
-	resetFormatted := resetTime.Format("15:04")
-
-	fmt.Println()
-	fmt.Println(styles.BoxStyle.Render(fmt.Sprintf(
-		"%s API Rate Limit Warning\n\n"+
-			"You have %s requests remaining out of %d.\n"+
-			"Your rate limit will reset at %s (%d minutes from now).",
-		styles.WarningStyle("⚠️"),
-		styles.HighlightStyleF(fmt.Sprintf("%d", remaining)),
-		limit,
-		styles.TimeStyle(resetFormatted),
-		minutesUntilReset,
-	)))
-	fmt.Println()
-}
-
-func displayRateLimitError(remaining, limit int, resetTime time.Time) {
-	timeUntilReset := time.Until(resetTime)
-	minutesUntilReset := int(timeUntilReset.Minutes())
-	resetFormatted := resetTime.Format("15:04")
-
-	fmt.Println()
-	fmt.Println(styles.BoxStyle.BorderForeground(styles.Love).Render(fmt.Sprintf(
-		"%s API Rate Limit Reached\n\n"+
-			"You have used all %d available requests.\n"+
-			"Your rate limit will reset at %s (%d minutes from now).\n\n"+
-			"%s To get more data, please wait until the limit resets.",
-		styles.ErrorStyle("❌"),
-		limit,
-		styles.TimeStyle(resetFormatted),
-		minutesUntilReset,
-		styles.InfoStyle("💡"),
-	)))
-	fmt.Println()
-}
-
-func displayRateLimitStatus(remaining, limit int) {
-	if limit <= 0 {
-		return
-	}
-
-	const barWidth = 20
-	used := limit - remaining
-
-	filledCount := min(int(float64(used)/float64(limit)*barWidth), barWidth)
-
-	emptyCount := barWidth - filledCount
-
-	filled := styles.HighlightStyleF(strings.Repeat("█", filledCount))
-	empty := strings.Repeat("░", emptyCount)
-
-	percentage := float64(used) / float64(limit) * 100
-
-	var usageText string
-	if percentage >= 90 {
-		usageText = styles.ErrorStyle(fmt.Sprintf("%.0f%% used", percentage))
-	} else if percentage >= 75 {
-		usageText = styles.WarningStyle(fmt.Sprintf("%.0f%% used", percentage))
-	} else {
-		usageText = styles.InfoStyle(fmt.Sprintf("%.0f%% used", percentage))
-	}
-
-	fmt.Printf("API Usage: [%s%s] %s (%d/%d)\n", filled, empty, usageText, used, limit)
 }
 
 func renderWeatherView(cli *CLI, weatherRenderer renderer.WeatherRenderer, city *models.City, weather *models.OneCallResponse, cfg *config.Config) {

--- a/internal/cli/weather_handler.go
+++ b/internal/cli/weather_handler.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/josephburgess/gust/internal/api"
 	"github.com/josephburgess/gust/internal/config"
@@ -17,6 +19,9 @@ func fetchAndRenderWeather(city string, cfg *config.Config, authConfig *config.A
 	fetchFunc := func() (*api.WeatherResponse, error) {
 		weather, err := client.GetWeather(city)
 		if err != nil {
+			if strings.Contains(strings.ToLower(err.Error()), "rate limit") {
+				return nil, fmt.Errorf("rate limit reached: %w", err)
+			}
 			return nil, fmt.Errorf("failed to get weather data: %w", err)
 		}
 		return weather, nil
@@ -24,6 +29,46 @@ func fetchAndRenderWeather(city string, cfg *config.Config, authConfig *config.A
 
 	message := fmt.Sprintf("Fetching weather for %s...", city)
 	weather, err := components.RunWithSpinner(message, components.WeatherEmojis, styles.Foam, fetchFunc)
+
+	if client.RateLimitInfo != nil && client.RateLimitInfo.Limit > 0 {
+		if err != nil && strings.Contains(strings.ToLower(err.Error()), "rate limit") {
+			displayRateLimitError(0, client.RateLimitInfo.Limit, client.RateLimitInfo.ResetTime)
+
+			timeUntilReset := time.Until(client.RateLimitInfo.ResetTime)
+			if timeUntilReset > 0 {
+				minutesRemaining := int(timeUntilReset.Minutes()) + 1
+				hoursRemaining := minutesRemaining / 60
+
+				if hoursRemaining > 0 {
+					remainingMinutes := minutesRemaining % 60
+					return fmt.Errorf("please try again in about %d hour(s) and %d minute(s) when your rate limit resets",
+						hoursRemaining, remainingMinutes)
+				} else {
+					return fmt.Errorf("please try again in about %d minute(s) when your rate limit resets",
+						minutesRemaining)
+				}
+			}
+			return fmt.Errorf("rate limit reached, please try again later")
+		}
+
+		if client.RateLimitInfo.Remaining <= 0 {
+			displayRateLimitError(0, client.RateLimitInfo.Limit, client.RateLimitInfo.ResetTime)
+		} else if client.RateLimitInfo.Remaining <= 5 {
+			displayRateLimitWarning(
+				client.RateLimitInfo.Remaining,
+				client.RateLimitInfo.Limit,
+				client.RateLimitInfo.ResetTime,
+			)
+		}
+
+		defer func() {
+			if client.RateLimitInfo.Remaining > 5 {
+				fmt.Println()
+				displayRateLimitStatus(client.RateLimitInfo.Remaining, client.RateLimitInfo.Limit)
+			}
+		}()
+	}
+
 	if err != nil {
 		return err
 	}
@@ -32,6 +77,74 @@ func fetchAndRenderWeather(city string, cfg *config.Config, authConfig *config.A
 	renderWeatherView(cli, weatherRenderer, weather.City, weather.Weather, cfg)
 
 	return nil
+}
+
+func displayRateLimitWarning(remaining, limit int, resetTime time.Time) {
+	timeUntilReset := time.Until(resetTime)
+	minutesUntilReset := int(timeUntilReset.Minutes())
+	resetFormatted := resetTime.Format("15:04")
+
+	fmt.Println()
+	fmt.Println(styles.BoxStyle.Render(fmt.Sprintf(
+		"%s API Rate Limit Warning\n\n"+
+			"You have %s requests remaining out of %d.\n"+
+			"Your rate limit will reset at %s (%d minutes from now).",
+		styles.WarningStyle("⚠️"),
+		styles.HighlightStyleF(fmt.Sprintf("%d", remaining)),
+		limit,
+		styles.TimeStyle(resetFormatted),
+		minutesUntilReset,
+	)))
+	fmt.Println()
+}
+
+func displayRateLimitError(remaining, limit int, resetTime time.Time) {
+	timeUntilReset := time.Until(resetTime)
+	minutesUntilReset := int(timeUntilReset.Minutes())
+	resetFormatted := resetTime.Format("15:04")
+
+	fmt.Println()
+	fmt.Println(styles.BoxStyle.BorderForeground(styles.Love).Render(fmt.Sprintf(
+		"%s API Rate Limit Reached\n\n"+
+			"You have used all %d available requests.\n"+
+			"Your rate limit will reset at %s (%d minutes from now).\n\n"+
+			"%s To get more data, please wait until the limit resets.",
+		styles.ErrorStyle("❌"),
+		limit,
+		styles.TimeStyle(resetFormatted),
+		minutesUntilReset,
+		styles.InfoStyle("💡"),
+	)))
+	fmt.Println()
+}
+
+func displayRateLimitStatus(remaining, limit int) {
+	if limit <= 0 {
+		return
+	}
+
+	const barWidth = 20
+	used := limit - remaining
+
+	filledCount := min(int(float64(used)/float64(limit)*barWidth), barWidth)
+
+	emptyCount := barWidth - filledCount
+
+	filled := styles.HighlightStyleF(strings.Repeat("█", filledCount))
+	empty := strings.Repeat("░", emptyCount)
+
+	percentage := float64(used) / float64(limit) * 100
+
+	var usageText string
+	if percentage >= 90 {
+		usageText = styles.ErrorStyle(fmt.Sprintf("%.0f%% used", percentage))
+	} else if percentage >= 75 {
+		usageText = styles.WarningStyle(fmt.Sprintf("%.0f%% used", percentage))
+	} else {
+		usageText = styles.InfoStyle(fmt.Sprintf("%.0f%% used", percentage))
+	}
+
+	fmt.Printf("API Usage: [%s%s] %s (%d/%d)\n", filled, empty, usageText, used, limit)
 }
 
 func renderWeatherView(cli *CLI, weatherRenderer renderer.WeatherRenderer, city *models.City, weather *models.OneCallResponse, cfg *config.Config) {

--- a/internal/cli/weather_handler.go
+++ b/internal/cli/weather_handler.go
@@ -1,5 +1,3 @@
-// Update the internal/cli/weather_handler.go file
-
 package cli
 
 import (

--- a/internal/ui/output/output.go
+++ b/internal/ui/output/output.go
@@ -38,10 +38,9 @@ func PrintRateLimitWarning(remaining, limit int, resetTime time.Time) {
 
 	fmt.Println()
 	fmt.Println(styles.BoxStyle.Render(fmt.Sprintf(
-		"%s API Rate Limit Warning\n\n"+
+		"⚠️ API Rate Limit Warning\n\n"+
 			"You have %s requests remaining out of %d.\n"+
 			"Your rate limit will reset at %s (%d minutes from now).",
-		styles.WarningStyle("⚠️"),
 		styles.HighlightStyleF(fmt.Sprintf("%d", remaining)),
 		limit,
 		styles.TimeStyle(resetFormatted),
@@ -57,14 +56,14 @@ func PrintRateLimitError(limit int, resetTime time.Time) {
 
 	fmt.Println()
 	fmt.Println(styles.BoxStyle.BorderForeground(styles.Love).Render(fmt.Sprintf(
-		"%s API Rate Limit Reached\n\n"+
-			"You have used all %d available requests.\n"+
+		"❌ API Rate Limit Reached\n\n"+
+			"Sorry - you have used all %d available requests.\n"+
+			"You must really like checking the weather!!\n"+
 			"Your rate limit will reset at %s (%d minutes from now).\n\n"+
-			styles.ErrorStyle("❌"),
+			"💡 If you think the limits are too low please get in touch :)",
 		limit,
 		styles.TimeStyle(resetFormatted),
 		minutesUntilReset,
-		styles.InfoStyle("💡"),
 	)))
 	fmt.Println()
 }

--- a/internal/ui/output/output.go
+++ b/internal/ui/output/output.go
@@ -60,8 +60,7 @@ func PrintRateLimitError(limit int, resetTime time.Time) {
 		"%s API Rate Limit Reached\n\n"+
 			"You have used all %d available requests.\n"+
 			"Your rate limit will reset at %s (%d minutes from now).\n\n"+
-			"%s To get more data, please wait until the limit resets.",
-		styles.ErrorStyle("❌"),
+			styles.ErrorStyle("❌"),
 		limit,
 		styles.TimeStyle(resetFormatted),
 		minutesUntilReset,

--- a/internal/ui/output/output.go
+++ b/internal/ui/output/output.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/josephburgess/gust/internal/ui/styles"
 )
@@ -29,3 +30,73 @@ func PrintHeader(title string) {
 func PrintBoxedMessage(message string) {
 	fmt.Println(styles.BoxStyle.Render(message))
 }
+
+func PrintRateLimitWarning(remaining, limit int, resetTime time.Time) {
+	timeUntilReset := time.Until(resetTime)
+	minutesUntilReset := int(timeUntilReset.Minutes())
+	resetFormatted := resetTime.Format("15:04")
+
+	fmt.Println()
+	fmt.Println(styles.BoxStyle.Render(fmt.Sprintf(
+		"%s API Rate Limit Warning\n\n"+
+			"You have %s requests remaining out of %d.\n"+
+			"Your rate limit will reset at %s (%d minutes from now).",
+		styles.WarningStyle("⚠️"),
+		styles.HighlightStyleF(fmt.Sprintf("%d", remaining)),
+		limit,
+		styles.TimeStyle(resetFormatted),
+		minutesUntilReset,
+	)))
+	fmt.Println()
+}
+
+func PrintRateLimitError(limit int, resetTime time.Time) {
+	timeUntilReset := time.Until(resetTime)
+	minutesUntilReset := int(timeUntilReset.Minutes())
+	resetFormatted := resetTime.Format("15:04")
+
+	fmt.Println()
+	fmt.Println(styles.BoxStyle.BorderForeground(styles.Love).Render(fmt.Sprintf(
+		"%s API Rate Limit Reached\n\n"+
+			"You have used all %d available requests.\n"+
+			"Your rate limit will reset at %s (%d minutes from now).\n\n"+
+			"%s To get more data, please wait until the limit resets.",
+		styles.ErrorStyle("❌"),
+		limit,
+		styles.TimeStyle(resetFormatted),
+		minutesUntilReset,
+		styles.InfoStyle("💡"),
+	)))
+	fmt.Println()
+}
+
+// going to implement this later - will create an api key status check endpoint
+/*
+func PrintRateLimitStatus(remaining, limit int) {
+	if limit <= 0 {
+		return
+	}
+
+	const barWidth = 20
+	used := limit - remaining
+
+	filledCount := min(int(float64(used) / float64(limit) * barWidth), barWidth)
+	emptyCount := barWidth - filledCount
+
+	filled := styles.HighlightStyleF(strings.Repeat("█", filledCount))
+	empty := strings.Repeat("░", emptyCount)
+
+	percentage := float64(used) / float64(limit) * 100
+
+	var usageText string
+	if percentage >= 90 {
+		usageText = styles.ErrorStyle(fmt.Sprintf("%.0f%% used", percentage))
+	} else if percentage >= 75 {
+		usageText = styles.WarningStyle(fmt.Sprintf("%.0f%% used", percentage))
+	} else {
+		usageText = styles.InfoStyle(fmt.Sprintf("%.0f%% used", percentage))
+	}
+
+	fmt.Printf("API Usage: [%s%s] %s (%d/%d)\n", filled, empty, usageText, used, limit)
+}
+*/


### PR DESCRIPTION
This pull request introduces rate limit rendering in gust. Rate limiting was implemented in breeze already but there was no warning for the user as to remaining requests. Now users will receive a helpful warning.

This is implemented alongside a PR to breeze to add the required info to the response headers for api calls: https://github.com/josephburgess/breeze/pull/12